### PR TITLE
Fix typo in member's Discord

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 Gnop! is a 4-directional Pong knockoff made in TIC-80 using Lua.
 
 ## Members' Discords:
-@jeezcalmdown #1305, @Swarupa V #7985, @desidesz19 #1293, @MasterOfTheTiget#8812
+@jeezcalmdown #1305, @Swarupa V #7985, @desidesz19 #1293, @MasterOfTheTiger#8812
 
 ## Required
 1. Download TIC-80 from https://tic80.com/create.


### PR DESCRIPTION
It's MasterOfTheTiger rather than MasterOfTheTiget. 